### PR TITLE
Switch footer logo to official Next Wave Dev logo (#66)

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 import { FooterLink } from "./microComponents/footer/footerLink";
 import { Separator } from "./microComponents/footer/separator";
-import NEXTWAVEDEV from "../images/NextWaveDevLogo/NextWaveDev_FINAL.png";
+import NEXTWAVEDEV from "../images/NextWaveDevLogo/NextWaveDev_FINAL_SMALL.jpg";
 import CANDID_SEAL from "../images/candid-transparency-logo.svg";
 import LINKEDIN_ICON from "../images/linkedin_logo.png";
 


### PR DESCRIPTION
<summary><strong>Summary & Changes 📃</strong></summary>

### Resolves
Issue  **#66 – Footer: Switch Current Logo**

---

### Summary
- This PR updates the footer to use the **official Next Wave Dev logo**.  
- Previously, the footer displayed an outdated logo.  
- The footer now correctly displays the official NWD logo from the project assets.

---

### Changes
✅ Replaced the existing footer logo with the official Next Wave Dev logo  
🛠️ No layout or styling changes  
🛠️ No breaking changes

---

### Testing 🧪
- Tested locally  
- Verified the footer logo displays correctly  
- Checked both desktop and mobile (responsive) views  
- No console errors observed  

📸 **Screenshot proof attached** showing the updated footer logo.
<img width="426" height="196" alt="Screenshot 2026-01-16 at 3 55 53 PM" src="https://github.com/user-attachments/assets/565fcd89-e7bb-4547-95e3-d22ce4746f65" />

---

### How to Test
1. Pull this branch  
2. Run `npm install`  
3. Run `npm start`  
4. Scroll to the footer  
5. Confirm the official Next Wave Dev logo is displayed

---

### Checklist ✅
- [x] Tested locally and works as expected  
- [x] Resolves issue #66  
- [x] Change is scoped only to the footer logo  
- [x] Ready for review and merge  