### PR TITLE
Add Join Us section with Graduates and Companies links to footer #83

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -73,6 +73,24 @@ const Footer = () => {
             <li style={{ ...footerList }}>nextwavedev.org@gmail.com</li>
           </Link>
         </ul>
+
+        <ul style={{ ...footerList }}>
+          <h4 style={{ ...footerCategory }}>Join Us</h4>
+          <Separator />
+          <ul
+            style={{
+              ...footerList,
+              display: "flex",
+              flexDirection: "row",
+              gap: "1rem",
+              flexWrap: "wrap",
+              justifyContent: "flex-start"
+            }}
+          >
+            <li><FooterLink name="Graduates" to="/graduates" /></li>
+            <li><FooterLink name="Companies" to="/companies" /></li>
+          </ul>
+        </ul>
       </div>
 
       <div


### PR DESCRIPTION
## Summary & Changes 📃

Resolves: Add “Join Us” Section to Footer Navigation #83

### Summary
This PR adds a new **“Join Us”** section to the footer navigation to make it easier for users to find ways to get involved.

### Changes
✅ Added a new **Join Us** menu item in the footer  
✅ Added sub-links for **Graduates** and **Companies**  
✅ Verified links redirect to the correct pages  
✅ Confirmed footer layout remains responsive and accessible  

<img width="1637" height="155" alt="Screenshot 2026-02-04 at 11 45 18 AM" src="https://github.com/user-attachments/assets/20e5714f-f7dd-453c-ab7a-8b16396d960a" />

### How to Test 🧪
1. Pull this branch
2. Run `npm install`
3. Run `npm start`
4. Scroll to the footer
5. Verify **Join Us** appears with **Graduates** and **Companies**
6. Click each link and confirm correct navigation

### Expected Behavior
- Footer displays the new **Join Us** section
- Sub-links work correctly
- No existing footer content is broken

### Additional Notes
- Only **one file** was changed: `src/components/Footer.js`
- Tested locally and verified visually

### Checklist ✅
- [x] Tested locally
- [x] Resolves an assigned issue
- [x] Changes are scoped and minimal
- [x] Ready for review