### PR TITLE
Add responsive rendering tests for key pages (#158)

### DIFF
--- a/src/tests/responsive.test.js
+++ b/src/tests/responsive.test.js
@@ -1,0 +1,52 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MemoryRouter } from "react-router-dom";
+
+import Main from "../pages/Main";
+import About from "../pages/About";
+import DevelopersPage from "../pages/DevelopersPage";
+import PortfolioPage from "../pages/PortfolioPage";
+
+function resizeWindow(width, height) {
+  window.innerWidth = width;
+  window.innerHeight = height;
+  window.dispatchEvent(new Event("resize"));
+}
+
+test("Home page renders on mobile", () => {
+  resizeWindow(375, 800);
+  render(
+    <MemoryRouter>
+      <Main />
+    </MemoryRouter>
+  );
+  expect(screen.getAllByText("Next Wave Dev").length).toBeGreaterThan(0);
+});
+
+test("About page renders on mobile", () => {
+  resizeWindow(375, 800);
+  render(
+    <MemoryRouter>
+      <About />
+    </MemoryRouter>
+  );
+});
+
+test("Developers page renders on mobile", () => {
+  resizeWindow(375, 800);
+  render(
+    <MemoryRouter>
+      <DevelopersPage />
+    </MemoryRouter>
+  );
+});
+
+test("Portfolio page renders on mobile", () => {
+  resizeWindow(375, 800);
+  render(
+    <MemoryRouter>
+      <PortfolioPage />
+    </MemoryRouter>
+  );
+});


### PR DESCRIPTION
**Summary**
Added automated tests to verify responsive rendering for key pages.

**Changes**
- Added responsive test for Home page
- Added tests for About, Developers, and Portfolio pages
- Simulated mobile viewport using resizeWindow helper

**Testing**
Tests were executed locally and passed successfully.

**How to Test** 

Run npm install
Run npm test
Press **a** to run all tests 
Verify that tests pass for:
Home page
About page
Developers page
Portfolio page
All tests should pass successfully.
<img width="1209" height="705" alt="Screenshot 2026-03-12 at 8 54 42 PM" src="https://github.com/user-attachments/assets/ade771a5-6980-4403-991a-defdaa27a3cd" />
