### PR TITLE
Fix/remove shop nav 135

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -54,15 +54,6 @@ const Footer = () => {
             <li><FooterLink name="Portfolio" /></li>
             <li><FooterLink name="Services" /></li>
             <li><FooterLink name="Pricing" /></li>
-
-            <a
-              href="https://bonfire.com/store/next-wave-dev-store"
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{ textDecoration: "none", color: "white" }}
-            >
-              Shop
-            </a>
             <li><FooterLink name="Donate" /></li>
           </ul>
         </ul>

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -136,13 +136,6 @@ const Navbar = () => {
               </div>
             )}
           </div>
-
-          <WhiteSpacing />
-          <Item
-            name="Shop"
-            to="https://bonfire.com/store/next-wave-dev-store/"
-            external
-          />
           <WhiteSpacing />
           <Item name="Donate" onClick={closeMenus} />
         </div>

--- a/tests/navbar-keyboard.spec.js
+++ b/tests/navbar-keyboard.spec.js
@@ -17,7 +17,6 @@ test('navbar links are reachable via keyboard', async ({ page }) => {
     'Portfolio',
     'Services',
     'Pricing',
-    'Shop',
     'Donate'
   ];
 


### PR DESCRIPTION
**Description** 
**Summary**

Removed the Shop navigation link from both the header and footer.

This change ensures the Shop link no longer appears in the site navigation and removes the external Bonfire store reference.

**Changes**

- Removed Shop link from src/components/Navbar.js

- Removed Shop link from src/components/Footer.js

- Updated tests/navbar-keyboard.spec.js to remove the Shop navigation item from keyboard navigation tests

**Result**

- The Shop tab no longer appears in the header navigation.

- The Shop tab no longer appears in the footer navigation.

- Navigation layout remains visually aligned.

- Keyboard navigation tests reflect the updated navigation structure.

**How to Test**

**1. Run the project locally**

npm install
npm start

Open: http://localhost:3000

**2. Verify Header Navigation**

Confirm the header contains:

Contact | About | Developers | Portfolio | Services | Pricing | Join Us | Donate

Ensure Shop is not present.

**3. Verify Footer Navigation**

Scroll to the footer and confirm the navigation shows:

Home | Contact | About | Developers | Portfolio | Services | Pricing | Donate

Ensure Shop is not present.

**4. Verify Navigation Works**

Click several links:

- Contact

- About

- Developers

- Portfolio

- Services

- Pricing

- Donate

Ensure they navigate correctly.



**Acceptance Criteria**

 - Shop removed from header navigation

 - Shop removed from footer navigation

 - No broken links or routes

 - Navigation layout remains aligned
<img width="1039" height="118" alt="Screenshot 2026-03-16 at 5 59 03 PM" src="https://github.com/user-attachments/assets/c6ec8346-6cf3-4ed5-8996-22680242c2b0" />
<img width="584" height="91" alt="Screenshot 2026-03-16 at 5 58 54 PM" src="https://github.com/user-attachments/assets/45b5a62e-d842-42c0-acc1-4fe09c8219c0" />
