### PR TITLE
Add E2E contact form test with network mocking

### DIFF
--- a/tests/contact.spec.js
+++ b/tests/contact.spec.js
@@ -1,15 +1,20 @@
 import { test, expect } from '@playwright/test';
 
 test('contact form submission shows success with mocked network', async ({ page }) => {
-  await page.goto('http://localhost:3000/#/Home', { waitUntil: 'domcontentloaded' });
-
-  await page.getByLabel('Name').fill('Test User');
-  await page.getByLabel('Email').fill('test@example.com');
-  await page.getByLabel('Message').fill('Hello from Playwright test!');
+  let mockedRequestSeen = false;
 
   await page.route(
-    'https://docs.google.com/forms/d/e/1FAIpQLSc6TcZviCuDGUOS0Nm4geU5rDJnDxlghpY4VMyPbFmZRU3-mg/formResponse',
+    '**/forms/d/e/1FAIpQLSc6TcZviCuDGUOS0Nm4geU5rDJnDxlghpY4VMyPbFmZRU3-mg/formResponse',
     async (route) => {
+      const request = route.request();
+
+      if (request.method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+
+      mockedRequestSeen = true;
+
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -18,7 +23,14 @@ test('contact form submission shows success with mocked network', async ({ page 
     }
   );
 
+  await page.goto('http://localhost:3000/#/Home', { waitUntil: 'domcontentloaded' });
+
+  await page.getByLabel('Name').fill('Test User');
+  await page.getByLabel('Email').fill('test@example.com');
+  await page.getByLabel('Message').fill('Hello from Playwright test!');
+
   await page.getByRole('button', { name: 'Submit' }).click();
 
+  expect(mockedRequestSeen).toBe(true);
   await expect(page).toHaveURL(/contact-thank-you/);
 });


### PR DESCRIPTION
## Summary
Implements an end-to-end Playwright test for the contact form using network mocking.

## Description
This PR adds a Playwright test (`tests/contact.spec.js`) that verifies the contact form submission flow without making real network requests.

## Key Features
- Uses `page.route()` to intercept the form submission request
- Mocks a successful `200 OK` response
- Prevents real requests to the external Google Forms endpoint
- Fills form inputs using accessible locators (`getByLabel`)
- Submits the form and verifies successful behavior (redirect to `/contact-thank-you`)

## Acceptance Criteria
- No real HTTP requests are sent during testing
- The mocked request returns a successful response
- The UI updates correctly after submission
- Test passes reliably and deterministically

## Files Added
- `tests/contact.spec.js`

🧪 How to Test

1. Start the local development server:
   npm run dev

2. Run the Playwright test:

npx playwright test tests/contact.spec.js

3. Expected Result:

- The test fills out the contact form

- Submits the form

- The network request is mocked (no real request sent)

- The app redirects to /contact-thank-you

- The test passes

Closes #63
<img width="724" height="83" alt="Screenshot 2026-03-19 at 11 42 02 PM" src="https://github.com/user-attachments/assets/2372ae31-91c8-498c-af09-ea7183ad3fde" />
