### PR TITLE
nwd-static-website_240_developer-page-remove-duplicates

### DIFF
--- a/src/components/Developer.js
+++ b/src/components/Developer.js
@@ -11,17 +11,7 @@ const Developer = ({ name, photo, degree, website, github, linkedin, role }) => 
         alt={name}
         className="developer-card__image"
       />
-      <div className='developers-flexcolumn__developer-flex-item__info-div'>
-        <div className='st-fl__st-fl-i__in-div__text'>
-          <div className='st-fl__st-fl-i__in-div__text__heading'>
-            <h2 style={styles.name}>{name}</h2>
-            <p className='developer-role'>{role}</p>
-          </div>
-
-          {/* REPLACED about → degree */}
-          <p style={styles.about}>{degree}</p>
-        </div>
-                     </div>
+      
       <div className="developer-card__body">
         <h2 className="developer-card__name">{name}</h2>
 

--- a/src/components/Developer.js
+++ b/src/components/Developer.js
@@ -11,7 +11,6 @@ const Developer = ({ name, photo, degree, website, github, linkedin, role }) => 
         alt={name}
         className="developer-card__image"
       />
-
       <div className="developer-card__body">
         <h2 className="developer-card__name">{name}</h2>
 

--- a/src/developers.json
+++ b/src/developers.json
@@ -72,15 +72,15 @@
       "github": "https://github.com/jmathew12",
       "linkedin": "https://www.linkedin.com/in/jmathew12/"
 
-        }, 
-            {
-          "name": "Azarias A'Neals",
-          "photo": "Azarias-ANeals.webp",
-          "role": "Student Developer",
-          "about": "I am a senior in the AD graduate program. I am passionate about application design, illustration, and full-stack development.",
-          "email": "zulbadamz@gmail.com",
-          "github": "https://github.com/Zulbadamz",
-          "linkedin": "https://www.linkedin.com/in/zulbadam-batdelger-aa91851b7/"
+    }, 
+    {
+      "name": "Azarias A'Neals",
+      "photo": "Azarias-ANeals.webp",
+      "role": "Student Developer",
+      "about": "I am a senior in the AD graduate program. I am passionate about application design, illustration, and full-stack development.",
+      "email": "zulbadamz@gmail.com",
+      "github": "https://github.com/Zulbadamz",
+      "linkedin": "https://www.linkedin.com/in/zulbadam-batdelger-aa91851b7/"
     },
     {
       "name": "Diego Cano",
@@ -90,15 +90,6 @@
       "email": "dcano2810@gmail.com",
       "github": "https://github.com/Diego-Cano",
       "linkedin": "https://www.linkedin.com/in/diegocanousa/"
-    },
-    {
-      "name": "Azarias A'Neals",
-      "photo": "Azarias-ANeals.webp",
-      "role": "Student Developer",
-      "degree": "BAS in Application Development",
-      "website": "",
-      "github": "https://github.com/AzariasANeals",
-      "linkedin": "https://www.linkedin.com/in/azarias-a-neals-64113a188/"
     },
     {
       "name": "Zulbadam Batdelger",


### PR DESCRIPTION
This PR resolves issue #240.

It used to show redundant information of the developers page. Now it has been removed. To test, run the program, go to developers page.
Before:
<img width="1903" height="812" alt="2026-05-19_14-22" src="https://github.com/user-attachments/assets/55a05e47-3314-46af-83e0-dfcd671a3693" />

After:
<img width="1889" height="788" alt="2026-05-19_14-21" src="https://github.com/user-attachments/assets/3537569a-bc4c-4fa1-8fb8-e6ef0bae9769" />
