### PR TITLE
nwd-static-website_242_clean-up-graduates-page

### DIFF
--- a/src/pages/GraduatesPage.js
+++ b/src/pages/GraduatesPage.js
@@ -6,6 +6,7 @@ import Section from "../components/Section";
 import TestimonialsSection from "../components/TestimonialsSection";
 import Button from "../components/Button";
 import { pageMetadata, BASE_URL } from "../utils/metadataConfig";
+import { Link } from "react-router-dom";
 
 function GraduatesPage() {
   const metadata = pageMetadata.graduates;
@@ -14,113 +15,232 @@ function GraduatesPage() {
     <>
       <Navbar />
 
-      <div>
-        <Section>
-          <div style={{ padding: "60px 40px", maxWidth: "1200px", margin: "0 auto" }}>
-            <Helmet>
-              <title>{metadata.title}</title>
-              <meta name="description" content={metadata.description} />
-              <meta name="viewport" content="width=device-width, initial-scale=1" />
-              <link rel="canonical" href={`${BASE_URL}/#${metadata.pageUrl}`} />
-              <meta property="og:type" content={metadata.type} />
-              <meta property="og:title" content={metadata.title} />
-              <meta property="og:description" content={metadata.description} />
-              <meta property="og:image" content={`${BASE_URL}/og-logo.png`} />
-              <meta property="og:image:alt" content="Next Wave Dev Graduates" />
-              <meta property="og:url" content={`${BASE_URL}/#${metadata.pageUrl}`} />
-              <meta property="og:site_name" content="Next Wave Dev" />
-              <meta name="twitter:card" content="summary_large_image" />
-              <meta name="twitter:title" content={metadata.title} />
-              <meta name="twitter:description" content={metadata.description} />
-              <meta name="twitter:image" content={`${BASE_URL}/og-logo.png`} />
-              <meta name="keywords" content="graduates, career launch, tech program, mentorship, experience" />
-              <meta name="author" content="Next Wave Dev" />
-            </Helmet>
 
-            <h1 style={{ marginBottom: "25px" }}>
-              Welcome
-            </h1>
-            <p style={{ marginBottom: "30px", lineHeight: "1.7", fontSize: "1.2rem" }}>
-              For Graduates – Launch Your Career with The Next Wave Dev
-            </p>
+      <div
+        style={{
+          padding: "60px 40px",
+          maxWidth: "1200px",
+          margin: "0 auto",
+        }}
+      >
 
-            <h2 style={{ marginTop: "40px", marginBottom: "15px" }}>
-              Future Tech Leader
-            </h2>
-            <p style={{ marginBottom: "40px", lineHeight: "1.7" }}>
-              You’ve got the skills. You’ve got the drive. Now, you need the experience that unlocks the door
-              to your dream job. Next Wave Dev is your fast-track solution to transforming your academic
-              knowledge into professional expertise.
-            </p>
+        <Helmet>
+        <title>Graduates - Next Wave Dev</title>
+        </Helmet>
 
-            <h2 style={{ marginTop: "40px", marginBottom: "15px" }}>
-              Why Join Next Wave?
-            </h2>
-            <p style={{ marginBottom: "40px", lineHeight: "1.7" }}>
-              The biggest barrier for new graduates is the “experience required” wall. We smash that wall by
-              placing you directly into real-world development environments.
-            </p>
+        <h1 style={{ marginBottom: "25px"}}>
+          For Graduates – Launch Your Career with The Next Wave Dev
+        </h1>
 
-            <div style={{ overflowX: "auto", marginBottom: "60px" }}>
-              <table style={{ width: "100%", borderCollapse: "collapse" }}>
-                <thead>
-                  <tr>
-                    <th style={thStyle}>Feature</th>
-                    <th style={thStyle}>Benefit</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td style={tdBold}>Real Company Projects</td>
-                    <td style={tdStyle}>Work on live, tangible projects used by businesses, not simulated assignments.</td>
-                  </tr>
-                  <tr>
-                    <td style={tdBold}>Professional Mentorship</td>
-                    <td style={tdStyle}>Get guidance from industry veterans who will review your code and share best practices.</td>
-                  </tr>
-                  <tr>
-                    <td style={tdBold}>Portfolio Builder</td>
-                    <td style={tdStyle}>Complete projects that you can proudly showcase during interviews, demonstrating capability over theory.</td>
-                  </tr>
-                  <tr>
-                    <td style={tdBold}>Industry Workflow</td>
-                    <td style={tdStyle}>Learn to use modern tools and work within a professional team structure.</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
+        <h2 style={{ marginTop: "40px", marginBottom: "15px"}}>
+          Welcome, Future Tech Leader!
+        </h2>
+        <p style={{ marginBottom: "30px", lineHeight: "1.7" }}>
+          You’ve got the skills. You’ve got the drive. Now, you need the experience that unlocks the door
+          to your dream job. Next Wave Dev is your fast-track solution to transforming your academic
+          knowledge into professional expertise.
+        </p>
 
-            <h2 style={{ marginTop: "40px", marginBottom: "15px" }}>
-              What You Will Gain
-            </h2>
-            <ul style={{ marginBottom: "60px", paddingLeft: "20px" }}>
-              <li style={{ marginBottom: "15px", lineHeight: "1.7" }}><strong>Verified Experience Hours:</strong> A proven track record of professional development work.</li>
-              <li style={{ marginBottom: "15px", lineHeight: "1.7" }}><strong>Strong Professional References:</strong> Connect with project managers and developers who can vouch for your skills.</li>
-              <li style={{ marginBottom: "15px", lineHeight: "1.7" }}><strong>Networking Opportunities:</strong> Build relationships with key contacts at potential hiring companies.</li>
-              <li style={{ marginBottom: "15px", lineHeight: "1.7" }}><strong>Confidence:</strong> Step into interviews knowing you have contributed to a company’s success.</li>
-            </ul>
+        <h2 style={{ marginTop: "40px", marginBottom: "15px"}}>
+          Why Join The Next Wave?
+        </h2>
+        <p style={{ marginBottom: "30px" }}>
+          The biggest barrier for new graduates is the “experience required” wall. We smash that wall by
+          placing you directly into real-world development environments.
+        </p>
 
-            <h2 style={{ marginTop: "40px", marginBottom: "15px" }}>
-              How It Works
-            </h2>
-            <ol style={{ fontSize: "1.2rem", lineHeight: "1.9", color: "#333", paddingLeft: "1.25rem", marginBottom: "60px" }}>
-              <li><strong>Apply:</strong> Tell us about your background, skills, and career goals.</li>
-              <li><strong>Match:</strong> We pair you with a company project that aligns with your skillset.</li>
-              <li><strong>Develop:</strong> You work with the company team and build your portfolio under mentorship.</li>
-            </ol>
+        <div style={{ overflowX: "auto", marginBottom: "60px" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+            <thead>
+              <tr>
+                <th style={thStyle}>
+                  Feature
+                </th>
+                <th style={thStyle}>
+                  Benefit
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td style={tdStyle}><strong>Real Company Projects</strong></td>
+                <td style={tdStyle}>
+                  Work on live, tangible projects used by businesses, not simulated assignments.
+                </td>
+              </tr>
+              <tr>
+                <td style={tdStyle}><strong>Professional Mentorship</strong></td>
+                <td style={tdStyle}>
+                  Get guidance from industry veterans who will review your code and share best practices.
+                </td>
+              </tr>
+              <tr>
+                <td style={tdStyle}><strong>Portfolio Builder</strong></td>
+                <td style={tdStyle}>
+                  Complete projects that you can proudly showcase during interviews, demonstrating
+                  capability over theory.
+                </td>
+              </tr>
+              <tr>
+                <td style={tdStyle}><strong>Industry Workflow</strong></td>
+                <td style={tdStyle}>
+                  Learn to use modern tools (like Git, Jira, Agile methodologies) and work within a
+                  professional team structure.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
 
-            <h2 style={{ marginTop: "40px", marginBottom: "15px" }}>
-              Ready to Stop Applying and Start Doing?
-            </h2>
+        <h2 style={{ marginTop: "40px", marginBottom: "15px"}}>
+          What You Will Gain
+        </h2>
+        <ul style={{ marginBottom: "60px", paddingLeft: "20px" }}>
+          <li style={{ marginBottom: "15px" }}>Verified Experience Hours: A proven track record of professional development work.</li>
+          <li style={{ marginBottom: "15px" }}>
+            Strong Professional References: Connect with project managers and developers who can vouch for
+            your skills.
+          </li>
+          <li style={{ marginBottom: "15px" }}>Networking Opportunities: Build relationships with key contacts at potential hiring companies.</li>
+          <li style={{ marginBottom: "15px" }}>
+            Confidence: Step into your next interview knowing you have already successfully contributed to
+            a company’s success.
+          </li>
+        </ul>
 
-            <Button to="/apply" variant="primary">
-              Apply Now & Start Building Your Portfolio
-            </Button>
-          </div>
-        </Section>
+        <h2 style={{ marginBottom: "20px" }}>
+          How It Works (3 Simple Steps)
+        </h2>
+        <ol style={{ fontSize: "1.2rem", lineHeight: "1.9", color: "#333", paddingLeft: "1.25rem" }}>
+          <li>
+            <strong>Apply:</strong> Tell us about your background, skills (languages, frameworks), and career goals.
+          </li>
+          <li>
+            <strong>Match:</strong> We carefully pair you with a company project that aligns with your skillset and
+            development interests.
+          </li>
+          <li>
+            <strong>Develop:</strong> You begin working with the company team, gaining experience, and building your
+            portfolio under mentorship.
+          </li>
+        </ol>
 
-        <TestimonialsSection type="graduates" />
+        <h2 style={{ marginTop: "40px", marginBottom: "15px"}}>
+          Ready to Stop Applying and Start Doing?
+        </h2>
+
+        <Button to="/apply" variant="primary">
+          Start Now
+        </Button>
       </div>
+      
+{/* =======
+      <Section>
+        <div style={{ padding: "60px 40px", maxWidth: "1200px", margin: "0 auto" }}>
+          <Helmet>
+            <title>{metadata.title}</title>
+            <meta name="description" content={metadata.description} />
+            <meta name="viewport" content="width=device-width, initial-scale=1" />
+            <link rel="canonical" href={`${BASE_URL}/#${metadata.pageUrl}`} />
+            <meta property="og:type" content={metadata.type} />
+            <meta property="og:title" content={metadata.title} />
+            <meta property="og:description" content={metadata.description} />
+            <meta property="og:image" content={`${BASE_URL}/og-logo.png`} />
+            <meta property="og:image:alt" content="Next Wave Dev Graduates" />
+            <meta property="og:url" content={`${BASE_URL}/#${metadata.pageUrl}`} />
+            <meta property="og:site_name" content="Next Wave Dev" />
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta name="twitter:title" content={metadata.title} />
+            <meta name="twitter:description" content={metadata.description} />
+            <meta name="twitter:image" content={`${BASE_URL}/og-logo.png`} />
+            <meta name="keywords" content="graduates, career launch, tech program, mentorship, experience" />
+            <meta name="author" content="Next Wave Dev" />
+          </Helmet>
+
+          <h1 style={{ marginBottom: "25px" }}>
+            For Graduates – Launch Your Career with The Next Wave Dev
+          </h1>
+
+          <h2 style={{ marginTop: "40px", marginBottom: "15px" }}>Welcome, Future Tech Leader!</h2>
+          <p style={{ marginBottom: "30px", lineHeight: "1.7" }}>
+            You’ve got the skills. You’ve got the drive. Now, you need the experience that unlocks the door
+            to your dream job. Next Wave Dev is your fast-track solution to transforming your academic
+            knowledge into professional expertise.
+          </p>
+
+          <h2 style={{ marginTop: "40px", marginBottom: "15px" }}>Why Join The Next Wave?</h2>
+          <p style={{ marginBottom: "30px" }}>
+            The biggest barrier for new graduates is the “experience required” wall. We smash that wall by
+            placing you directly into real-world development environments.
+          </p>
+
+          <div style={{ overflowX: "auto", marginBottom: "60px" }}>
+            <table style={{ width: "100%", borderCollapse: "collapse" }}>
+              <thead>
+                <tr>
+                  <th style={thStyle}>Feature</th>
+                  <th style={thStyle}>Benefit</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td style={tdStyle}><strong>Real Company Projects</strong></td>
+                  <td style={tdStyle}>Work on live, tangible projects used by businesses, not simulated assignments.</td>
+                </tr>
+                <tr>
+                  <td style={tdStyle}><strong>Professional Mentorship</strong></td>
+                  <td style={tdStyle}>Get guidance from industry veterans who will review your code and share best practices.</td>
+                </tr>
+                <tr>
+                  <td style={tdStyle}><strong>Portfolio Builder</strong></td>
+                  <td style={tdStyle}>Complete projects that you can proudly showcase during interviews, demonstrating capability over theory.</td>
+                </tr>
+                <tr>
+                  <td style={tdStyle}><strong>Industry Workflow</strong></td>
+                  <td style={tdStyle}>Learn to use modern tools and work within a professional team structure.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h2 style={{ marginTop: "40px", marginBottom: "15px" }}>What You Will Gain</h2>
+          <ul style={{ marginBottom: "60px", paddingLeft: "20px" }}>
+            <li style={{ marginBottom: "15px" }}>Verified Experience Hours: A proven track record of professional development work.</li>
+            <li style={{ marginBottom: "15px" }}>Strong Professional References: Connect with project managers and developers who can vouch for your skills.</li>
+            <li style={{ marginBottom: "15px" }}>Networking Opportunities: Build relationships with key contacts at potential hiring companies.</li>
+            <li style={{ marginBottom: "15px" }}>Confidence: Step into interviews knowing you have contributed to a company’s success.</li>
+          </ul>
+
+          <h2 style={{ marginBottom: "20px" }}>How It Works (3 Simple Steps)</h2>
+          <ol style={{ fontSize: "1.2rem", lineHeight: "1.9", color: "#333", paddingLeft: "1.25rem" }}>
+            <li><strong>Apply:</strong> Tell us about your background, skills, and career goals.</li>
+            <li><strong>Match:</strong> We pair you with a company project that aligns with your skillset.</li>
+            <li><strong>Develop:</strong> You work with the company team and build your portfolio under mentorship.</li>
+          </ol>
+
+          <h2 style={{ marginTop: "40px", marginBottom: "15px" }}>
+            Ready to Stop Applying and Start Doing?
+          </h2>
+
+          <Link
+            to="/apply"
+            style={{
+              display: "inline-block",
+              padding: "12px 20px",
+              borderRadius: "6px",
+              textDecoration: "none",
+              fontWeight: "bold",
+              backgroundColor: "#007BFF",
+              color: "white",
+            }}
+            aria-label="Apply Now & Start Building Your Portfolio"
+          >
+            Apply Now &amp; Start Building Your Portfolio
+          </Link>
+        </div>
+      </Section> */}
+
+      <TestimonialsSection type="graduates" />
       <Footer />
     </>
   );
@@ -133,13 +253,6 @@ const thStyle = {
 
 const tdStyle = {
   padding: "10px",
-};
-
-const tdBold = {
-  padding: "10px",
-  fontWeight: "bold",
-  verticalAlign: "top",
-  whiteSpace: "nowrap",
 };
 
 export default GraduatesPage;


### PR DESCRIPTION
This PR resolves issue #242 

This removes the redundant info that was on the graduates page. Also changed the apply now to start now since the phrase above says "Ready to Stop Applying and Start Doing?"

Before:

https://github.com/user-attachments/assets/24586738-3608-4ef7-8898-3ef75fac185d



After:

https://github.com/user-attachments/assets/68bbc63b-6f47-4add-8dda-3cdcac10d793


