### PR TITLE
Update Companies Page hero heading

### DIFF
--- a/src/pages/CompaniesPage.js
+++ b/src/pages/CompaniesPage.js
@@ -51,7 +51,7 @@ function CompaniesPage() {
                 </Helmet>
 
                 <h1 style={{marginBottom: "25px"}}>
-                    For Companies – Secure Your Future Talent Pipeline
+                    Secure Your Future Talent Pipeline
                 </h1>
 
                 <h2 style={{ marginTop: "40px", marginBottom: "15px"}}>


### PR DESCRIPTION
issue: #257 

Summary:  Updated the first heading on the Companies page by removing the prefix “for companies –” so the heading now reads: secure your future talent pipeline

Verification:
`npm install`
`npm start`
Click on "Hire Us"  -> "Companies" 
Verify that it is saying:
"Secure Your Future Talent Pipeline"
Instead of 
"For Companies - Secure Your Future Talent Pipeline"

Media:
<img width="1891" height="799" alt="image" src="https://github.com/user-attachments/assets/4a17db83-8d42-4cb8-b7f6-ce432cbdba10" />
