### PR TITLE
Update Graduates Page hero heading

### DIFF
--- a/src/pages/GraduatesPage.js
+++ b/src/pages/GraduatesPage.js
@@ -41,7 +41,7 @@ function GraduatesPage() {
               Welcome
             </h1>
             <p style={{ marginBottom: "30px", lineHeight: "1.7", fontSize: "1.2rem" }}>
-              For Graduates – Launch Your Career with The Next Wave Dev
+              Launch Your Career with The Next Wave Dev
             </p>
 
             <h2 style={{ marginTop: "40px", marginBottom: "15px" }}>


### PR DESCRIPTION
Issue: #256 
Summary
Updated the first heading on the Graduates page by removing the prefix “for graduates –” so the heading now reads:

launch your career with next wave dev

Why
This aligns the page with the updated content strategy and keeps the messaging clean, direct, and user‑focused.

Verification
Confirmed the updated heading renders correctly on the Graduates page

No layout or styling regressions observed

Navigation and surrounding content remain unaffected

Verification:
npm install
npm start
Click on "Join Us" -> "Graduate"
Verify that it is saying:
"Launch Your Career with The Next Wave Dev"
Instead of
"For Graduates - Launch Your Career with The Next Wave Dev"

Media:
<img width="1904" height="755" alt="image" src="https://github.com/user-attachments/assets/d4860b95-ae23-41ee-b670-7a0c0a198752" />
