### PR TITLE
 nwd-static-website_258_update-matching-copy-on-companies-page

### DIFF
--- a/src/pages/CompaniesPage.js
+++ b/src/pages/CompaniesPage.js
@@ -178,13 +178,11 @@ function CompaniesPage() {
                                     <h3 style={cardTitle}>2. Matching</h3>
 
                                     <p>
-                                        <strong>Our Role:</strong> We vet and match the top
-                                        candidates for your project.
+                                        <strong>Our Role:</strong> We vet, interview, and match you with our top candidates whose skills align perfectly.
                                     </p>
 
                                     <p>
-                                        <strong>Your Role:</strong> Interview final candidates
-                                        and select your preferred team members.
+                                        <strong>Your Role:</strong> Once your team has been selected, introduce yourselves through our integrated messaging system.
                                     </p>
                                 </div>
 


### PR DESCRIPTION
This PR resolves issue #258 

It updates the text on developers page. 

Run the app
Navigate to companies page 

Before:
<img width="1245" height="628" alt="2026-05-23_22-18" src="https://github.com/user-attachments/assets/6def488c-1576-40e2-b26b-2562e903cf86" />


After:
<img width="1230" height="640" alt="2026-05-23_22-17" src="https://github.com/user-attachments/assets/27dc9501-668d-4f07-810c-cf7775b28f31" />
