### PR TITLE
fix: remove Companies from Join Us dropdown

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -187,9 +187,7 @@ const Navbar = () => {
           >
             <span
               className={`nav-dropdown-toggle ${
-                location.pathname === "/graduates"
-                  ? "active-nav-link"
-                  : ""
+                location.pathname === "/graduates" ? "active-nav-link" : ""
               }`}
               onClick={() => {
                 setIsDropdownOpen(!isDropdownOpen);
@@ -277,14 +275,6 @@ const Navbar = () => {
                     </div>
                   )}
                 </div>
-
-                <Link
-                  to="/companies"
-                  className="nav-dropdown-item"
-                  onClick={closeMenus}
-                >
-                  Companies
-                </Link>
               </div>
             )}
           </div>


### PR DESCRIPTION
# Fix #243 — Remove "Companies" from "Join Us" dropdown

##  What changed

Removed the "Companies" link from the "Join Us" dropdown menu in `Navbar.jsx`. This item is no longer needed per issue #243.

## Files modified

- `src/components/Navbar.jsx`

## Changes made

- Deleted the `<Link to="/companies">` item nested inside the `isDropdownOpen` section of the Join Us dropdown
- No other nav items were affected — the "Companies" link inside the **Hire Us** dropdown remains untouched
- Dropdown height and spacing adjust automatically since the menu is flex-column layout — no CSS changes needed

## Before / After

**Before:** Join Us dropdown showed → Graduates, Companies  
**After:** Join Us dropdown shows → Graduates only

## Testing

- [x] Desktop: hover over Join Us to confirm only Graduates appears
- [x] Mobile: tap Join Us to confirm only Graduates appears  
- [x] Graduates nested submenu (Apply) still works correctly
- [x] Hire Us dropdown still shows Companies and Pricing (unchanged)


https://github.com/user-attachments/assets/be820c60-2702-4117-9b18-3508e2cfef6e

