### PR TITLE
Add contact form validation tests

### DIFF
--- a/src/components/microComponents/contact/form.js
+++ b/src/components/microComponents/contact/form.js
@@ -17,17 +17,24 @@ export function FormComponent() {
   const handleSubmit = async (e) => {
     e.preventDefault();
 
-    const name = e.target["entry.2005620554"].value.trim();
-    const email = e.target["emailAddress"].value.trim();
-    const msg = message.trim();   
+    const form = new FormData(e.target);
 
-    if (!name || !email || !msg) {
-      alert("Fields cannot be empty.");
+    const name = form.get("entry.2005620554")?.trim();
+    const email = form.get("emailAddress")?.trim();
+    const msg = message.trim();
+
+    if (!email) {
+      setErrorMessage("Email is required");
+      return;
+    }
+    
+    if (!name || !msg) {
+      setErrorMessage("Fields cannot be empty.");
       return;
     }
 
     if (!email.includes("@")) {
-      alert("Invalid email.");
+      setErrorMessage("Invalid email.");
       return;
     }
 

--- a/src/pages/Contact.test.js
+++ b/src/pages/Contact.test.js
@@ -33,13 +33,14 @@ describe("Contact Page Integration Tests", () => {
       </MemoryRouter>
     );
 
-    // Select inputs by name attribute (stable and safe)
     const nameInput = document.querySelector(
       'input[name="entry.2005620554"]'
     );
+
     const emailInput = document.querySelector(
       'input[name="emailAddress"]'
     );
+
     const messageInput = document.querySelector(
       'textarea[name="entry.839337160"]'
     );
@@ -53,6 +54,37 @@ describe("Contact Page Integration Tests", () => {
     );
 
     expect(global.fetch).toHaveBeenCalled();
-    expect(mockedNavigate).toHaveBeenCalledWith("/contact-thank-you");
+    expect(mockedNavigate).toHaveBeenCalledWith(
+      "/contact-thank-you"
+    );
+  });
+
+  test("Validation: shows error when email is empty and does not submit", async () => {
+    render(
+      <MemoryRouter>
+        <Contact />
+      </MemoryRouter>
+    );
+
+    const nameInput = document.querySelector(
+      'input[name="entry.2005620554"]'
+    );
+
+    const messageInput = document.querySelector(
+      'textarea[name="entry.839337160"]'
+    );
+
+    await userEvent.type(nameInput, "Beimnet");
+    await userEvent.type(messageInput, "Hello test message");
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /submit/i })
+    );
+
+    expect(global.fetch).not.toHaveBeenCalled();
+
+    expect(
+      screen.getByText(/email is required/i)
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary & Changes 📃

Resolves: #60

Description:
Added integration tests for the Contact page to verify form validation and submission behavior.

Changes:

* Created `src/pages/Contact.test.js`
* Added Happy Path test to verify successful form submission and redirect
* Added Validation test to verify empty email prevents submission
* Mocked API requests to avoid real network calls
* Updated contact form validation handling to show DOM feedback messages

How to Test:

1. Run:

   ```
   npm test -- Contact.test.js
   ```
2. Verify:

   * Valid form submits successfully and redirects to `/contact-thank-you`
   * Empty email shows validation feedback
   * Invalid form does not submit

Result:
All Contact integration tests pass successfully.
<img width="1280" height="800" alt="Screenshot 2026-06-13 at 11 53 44 PM" src="https://github.com/user-attachments/assets/6d6f2269-c7fb-44d2-b29c-39c3827a9332" />
